### PR TITLE
Docs | Fix Auth0 integration instructions (fix #2655)

### DIFF
--- a/docs/graphql/manual/guides/integrations/auth0-jwt.rst
+++ b/docs/graphql/manual/guides/integrations/auth0-jwt.rst
@@ -32,7 +32,7 @@ In the dashboard, navigate to ``Rules``. Add the following rules to add our cust
 
     function (user, context, callback) {
       const namespace = "https://hasura.io/jwt/claims";
-      context.idToken[namespace] = 
+      context.accessToken[namespace] = 
         { 
           'x-hasura-default-role': 'user',
           // do some custom logic to decide allowed roles
@@ -44,6 +44,25 @@ In the dashboard, navigate to ``Rules``. Add the following rules to add our cust
 
 
 .. _test-auth0:
+
+Create an Auth0 API
+^^^^^^^^^^^^^^^^^^^
+
+- Navigate to the `Auth0 dashboard <https://manage.auth0.com>`__.
+- Click on the ``API`` menu option on the left and then click the ``+ Create API`` button.
+- In the ``New API`` window, set a name for your API and enter an ``identifier`` (e.g. ``hasura``)
+- In your application code, configure your API ``identifier`` as the ``audience`` when initializing Auth0, e.g.:
+
+.. code-block:: javascript
+
+    <Auth0Provider
+      domain={process.env.AUTH_DOMAIN}
+      client_id={process.env.AUTH_CLIENT_ID}
+      redirect_uri={window.location.origin}
+      onRedirectCallback={() => ..}
+      audience="hasura"
+    >
+
 
 Test auth0 login and generate sample JWTs for testing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
The current documentation for the Auth0 integration is incorrect. Users are not able to connect Auth0 and Hasura.

### Affected components 
<!-- Remove non-affected components from the list -->

- Docs

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#2655

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
Adding the Hasura claims to the `idToken` no longer works. Auth0 only returns a JWT for access tokens. It is hence required to create an API within Auth0 and use its access token to communicate with Hasura.
